### PR TITLE
Address all open issues (#2–#8): PyO3, search fix, bi-temporal KG, duplicate detection, CLI

### DIFF
--- a/rust/gp-bench/benches/palace_benchmarks.rs
+++ b/rust/gp-bench/benches/palace_benchmarks.rs
@@ -40,7 +40,7 @@ fn search_benchmark(c: &mut Criterion) {
     let mut palace = make_palace(100);
     c.bench_function("search_100_drawers", |b| {
         b.iter(|| {
-            let _ = palace.search_mut(black_box("benchmark drawer content"), 10);
+            let _ = palace.search(black_box("benchmark drawer content"), 10);
         });
     });
 }

--- a/rust/gp-bench/src/bin/onnx_eval.rs
+++ b/rust/gp-bench/src/bin/onnx_eval.rs
@@ -119,7 +119,7 @@ fn run_search_quality(palace: &mut GraphPalace) {
     println!("|---|-------|-------------|---------|-------|-----|-------------|");
 
     for (i, test) in SEARCH_TESTS.iter().enumerate() {
-        let results = palace.search_mut(test.query, 10).unwrap_or_default();
+        let results = palace.search(test.query, 10).unwrap_or_default();
 
         let top1_match = results.first()
             .is_some_and(|r| r.content.contains(test.expected_top));
@@ -163,7 +163,7 @@ fn run_search_quality(palace: &mut GraphPalace) {
     if fail > 0 {
         println!("\n  Failed queries:");
         for (i, test) in SEARCH_TESTS.iter().enumerate() {
-            let results = palace.search_mut(test.query, 3).unwrap_or_default();
+            let results = palace.search(test.query, 3).unwrap_or_default();
             let top1_match = results.first()
                 .is_some_and(|r| r.content.contains(test.expected_top));
             if !top1_match {
@@ -200,7 +200,7 @@ fn run_throughput_benchmarks(palace: &mut GraphPalace) {
     let mut total_us = 0u128;
     for q in &queries {
         let t0 = Instant::now();
-        let _ = palace.search_mut(q, 10);
+        let _ = palace.search(q, 10);
         let elapsed = t0.elapsed();
         total_us += elapsed.as_micros();
         println!("  '{}...' → {:.1}ms", &q[..q.len().min(40)], elapsed.as_secs_f64() * 1000.0);
@@ -260,7 +260,7 @@ fn run_pheromone_test(palace: &mut GraphPalace) {
     println!("╚══════════════════════════════════════════════════════════════╝\n");
 
     // 1. Search for something and deposit pheromones on the path
-    let results = palace.search_mut("pheromone navigation stigmergy", 3).unwrap();
+    let results = palace.search("pheromone navigation stigmergy", 3).unwrap();
     println!("Search for 'pheromone navigation stigmergy':");
     for (i, r) in results.iter().enumerate() {
         println!("  {}: [score={:.4}] {} (id={})", i+1, r.score, &r.content[..r.content.len().min(70)], r.drawer_id);
@@ -291,7 +291,7 @@ fn run_pheromone_test(palace: &mut GraphPalace) {
     }
 
     // 4. Search again — pheromone boost should change ranking
-    let results2 = palace.search_mut("pheromone navigation stigmergy", 3).unwrap();
+    let results2 = palace.search("pheromone navigation stigmergy", 3).unwrap();
     println!("\n### Re-search after pheromone deposit:");
     for (i, r) in results2.iter().enumerate() {
         println!("  {}: [score={:.4}] {} (id={})", i+1, r.score, &r.content[..r.content.len().min(70)], r.drawer_id);
@@ -510,7 +510,7 @@ fn main() {
 
     let mut pass = 0;
     for (query, expected) in &spot_checks {
-        let results = palace.search_mut(query, 1).unwrap();
+        let results = palace.search(query, 1).unwrap();
         let hit = results.first().is_some_and(|r| r.content.contains(expected));
         if hit { pass += 1; }
         let mark = if hit { "PASS" } else { "FAIL" };

--- a/rust/gp-bench/src/generators.rs
+++ b/rust/gp-bench/src/generators.rs
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn generate_palace_tfidf_search_returns_results() {
         let (mut palace, _) = generate_palace_tfidf(1, 2, 5, 0);
-        let results = palace.search_mut("quantum entanglement", 5).unwrap();
+        let results = palace.search("quantum entanglement", 5).unwrap();
         assert!(!results.is_empty(), "TF-IDF search should return results");
     }
 

--- a/rust/gp-bench/src/throughput.rs
+++ b/rust/gp-bench/src/throughput.rs
@@ -104,7 +104,7 @@ pub fn measure_search_throughput(
 
     let t0 = Instant::now();
     for q in &queries {
-        let _ = palace.search_mut(q, 10);
+        let _ = palace.search(q, 10);
     }
     let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
 

--- a/rust/gp-cli/src/main.rs
+++ b/rust/gp-cli/src/main.rs
@@ -39,6 +39,10 @@ struct Cli {
     #[arg(short, long, default_value = "graphpalace.toml")]
     config: String,
 
+    /// Suppress informational messages (e.g. tunnel build counts)
+    #[arg(short, long)]
+    quiet: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -217,6 +221,9 @@ enum RoomCommands {
         /// Hall type: facts, events, discoveries, preferences, advice
         #[arg(short = 't', long, default_value = "facts")]
         hall_type: String,
+        /// Description
+        #[arg(short, long)]
+        description: Option<String>,
     },
 }
 
@@ -426,7 +433,7 @@ fn load_palace_config(db_path: &str, config_file: &str) -> GraphPalaceConfig {
 
 
 
-fn load_or_create_palace(db_path: &str, config_file: &str) -> Result<GraphPalace> {
+fn load_or_create_palace(db_path: &str, config_file: &str, quiet: bool) -> Result<GraphPalace> {
     let config = load_palace_config(db_path, config_file);
     let storage = InMemoryBackend::new();
 
@@ -455,7 +462,7 @@ fn load_or_create_palace(db_path: &str, config_file: &str) -> Result<GraphPalace
 
         // Auto-build tunnels between rooms in different wings for cross-wing navigation
         let tunnel_count = palace.build_tunnels(0.3).unwrap_or(0);
-        if tunnel_count > 0 {
+        if tunnel_count > 0 && !quiet {
             eprintln!("Built {tunnel_count} tunnel(s) for cross-wing navigation");
         }
     }
@@ -577,7 +584,7 @@ impl ToolHandler for PalaceToolHandler {
                     .and_then(|a| a.get("k"))
                     .and_then(|v| v.as_u64())
                     .unwrap_or(10) as usize;
-                match self.palace.search_mut(query, k) {
+                match self.palace.search(query, k) {
                     Ok(results) => {
                         let results_json: Vec<Value> = results.iter().map(|r| serde_json::json!({
                             "drawer_id": r.drawer_id,
@@ -703,9 +710,10 @@ impl ToolHandler for PalaceToolHandler {
                 let wing_id = arguments.and_then(|a| a.get("wing_id")).and_then(|v| v.as_str());
                 let name = arguments.and_then(|a| a.get("name")).and_then(|v| v.as_str());
                 let htype = arguments.and_then(|a| a.get("hall_type")).and_then(|v| v.as_str()).unwrap_or("facts");
+                let desc = arguments.and_then(|a| a.get("description")).and_then(|v| v.as_str());
                 match (wing_id, name) {
                     (Some(wid), Some(n)) => {
-                        match self.palace.add_room(wid, n, parse_hall_type(htype)) {
+                        match self.palace.add_room_with_description(wid, n, parse_hall_type(htype), desc) {
                             Ok(id) => {
                                 self.auto_save();
                                 ToolCallResult::text(serde_json::json!({
@@ -727,7 +735,7 @@ impl ToolHandler for PalaceToolHandler {
                     .unwrap_or(0.85) as f32;
                 match content {
                     Some(c) => {
-                        match self.palace.search_mut(c, 5) {
+                        match self.palace.search(c, 5) {
                             Ok(results) => {
                                 let dupes: Vec<Value> = results.iter()
                                     .filter(|r| r.score >= threshold)
@@ -757,9 +765,31 @@ impl ToolHandler for PalaceToolHandler {
                     .and_then(|a| a.get("confidence"))
                     .and_then(|v| v.as_f64())
                     .unwrap_or(0.5);
+                let valid_from_str = arguments.and_then(|a| a.get("valid_from")).and_then(|v| v.as_str());
+                let valid_to_str = arguments.and_then(|a| a.get("valid_to")).and_then(|v| v.as_str());
+                let statement_type_str = arguments.and_then(|a| a.get("statement_type")).and_then(|v| v.as_str());
+                let has_temporal = valid_from_str.is_some() || valid_to_str.is_some() || statement_type_str.is_some();
                 match (subject, predicate, object) {
                     (Some(s), Some(p), Some(o)) => {
-                        match self.palace.kg_add_with_confidence(s, p, o, confidence) {
+                        let result = if has_temporal {
+                            use gp_core::types::StatementType;
+                            let st = match statement_type_str.unwrap_or("fact") {
+                                "observation" => StatementType::Observation,
+                                "inference" => StatementType::Inference,
+                                "hypothesis" => StatementType::Hypothesis,
+                                _ => StatementType::Fact,
+                            };
+                            let vf = valid_from_str
+                                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                                .map(|dt| dt.with_timezone(&chrono::Utc));
+                            let vt = valid_to_str
+                                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                                .map(|dt| dt.with_timezone(&chrono::Utc));
+                            self.palace.kg_add_temporal(s, p, o, confidence, vf, vt, st)
+                        } else {
+                            self.palace.kg_add_with_confidence(s, p, o, confidence)
+                        };
+                        match result {
                             Ok(id) => {
                                 self.auto_save();
                                 ToolCallResult::text(serde_json::json!({
@@ -787,6 +817,11 @@ impl ToolHandler for PalaceToolHandler {
                                     "predicate": r.predicate,
                                     "object": r.object,
                                     "confidence": r.confidence,
+                                    "valid_from": r.valid_from,
+                                    "valid_to": r.valid_to,
+                                    "observed_at": r.observed_at,
+                                    "invalidated_at": r.invalidated_at,
+                                    "statement_type": r.statement_type.to_string(),
                                 })).collect();
                                 ToolCallResult::text(serde_json::json!({
                                     "entity": e,
@@ -855,6 +890,11 @@ impl ToolHandler for PalaceToolHandler {
                                     "predicate": r.predicate,
                                     "object": r.object,
                                     "confidence": r.confidence,
+                                    "valid_from": r.valid_from,
+                                    "valid_to": r.valid_to,
+                                    "observed_at": r.observed_at,
+                                    "invalidated_at": r.invalidated_at,
+                                    "statement_type": r.statement_type.to_string(),
                                 })).collect();
                                 ToolCallResult::text(serde_json::json!({
                                     "entity": e,
@@ -877,6 +917,7 @@ impl ToolHandler for PalaceToolHandler {
                                     "subject": r.subject,
                                     "predicate": r.predicate,
                                     "object": r.object,
+                                    "statement_type": r.statement_type.to_string(),
                                 })).collect();
                                 ToolCallResult::text(serde_json::json!({
                                     "start": s,
@@ -1078,7 +1119,7 @@ fn main() -> Result<()> {
             }
         }
         Commands::AddDrawer { content, wing, room, source } => {
-            let mut palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let mut palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             let source = parse_drawer_source(&source);
             let id = palace.add_drawer(&content, &wing, &room, source)?;
             save_palace(&palace, &cli.db)?;
@@ -1088,10 +1129,10 @@ fn main() -> Result<()> {
             println!("  Content: {}...", truncate_str(&content, 80));
         }
         Commands::Search { query, wing, room, k } => {
-            let mut palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let mut palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             // Fetch more results if filtering, so we still get k after filter
             let fetch_k = if wing.is_some() || room.is_some() { k * 5 } else { k };
-            let mut results = palace.search_mut(&query, fetch_k)?;
+            let mut results = palace.search(&query, fetch_k)?;
             // Apply wing/room filters
             if let Some(ref w) = wing {
                 results.retain(|r| r.wing_name == *w);
@@ -1113,7 +1154,7 @@ fn main() -> Result<()> {
             }
         }
         Commands::Navigate { from, to, context } => {
-            let palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             match palace.navigate(&from, &to, Some(&context)) {
                 Ok(path) => {
                     println!("Path found: {} → {}", from, to);
@@ -1129,7 +1170,7 @@ fn main() -> Result<()> {
             }
         }
         Commands::Status { verbose } => {
-            let palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             let status = palace.status()?;
             println!("Palace: {}", status.name);
             println!("  Wings:         {}", status.wing_count);
@@ -1149,7 +1190,7 @@ fn main() -> Result<()> {
             if format == "cypher" {
                 anyhow::bail!("Cypher format is not yet supported. Use JSON (default).");
             }
-            let palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             let export = palace.export()?;
             let json = export.to_json_pretty()?;
             std::fs::write(&output, &json)?;
@@ -1159,7 +1200,7 @@ fn main() -> Result<()> {
             if format == "cypher" {
                 anyhow::bail!("Cypher format is not yet supported. Use JSON (default).");
             }
-            let palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             let json = std::fs::read_to_string(&input)
                 .with_context(|| format!("reading {input}"))?;
             let export = PalaceExport::from_json(&json)?;
@@ -1177,7 +1218,7 @@ fn main() -> Result<()> {
         }
         Commands::Wing { command } => match command {
             WingCommands::List => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let wings = palace.storage().list_wings();
                 if wings.is_empty() {
                     println!("No wings found. Use 'graphpalace wing add' to create one.");
@@ -1191,7 +1232,7 @@ fn main() -> Result<()> {
                 }
             }
             WingCommands::Add { name, wing_type, description } => {
-                let mut palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let mut palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let wt = parse_wing_type(&wing_type);
                 let desc = description.as_deref().unwrap_or(&name);
                 let id = palace.add_wing(&name, wt, desc)?;
@@ -1201,7 +1242,7 @@ fn main() -> Result<()> {
         },
         Commands::Room { command } => match command {
             RoomCommands::List { wing } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 // Find wing by name
                 let wing_obj = palace.storage().find_wing_by_name(&wing);
                 match wing_obj {
@@ -1221,14 +1262,19 @@ fn main() -> Result<()> {
                     None => println!("Wing '{wing}' not found"),
                 }
             }
-            RoomCommands::Add { wing, name, hall_type } => {
-                let mut palace = load_or_create_palace(&cli.db, &cli.config)?;
+            RoomCommands::Add { wing, name, hall_type, description } => {
+                let mut palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let wing_obj = palace.storage().find_wing_by_name(&wing);
                 match wing_obj {
                     Some(w) => {
                         let ht = parse_hall_type(&hall_type);
                         let wing_id = w.id.clone();
-                        let id = palace.add_room(&wing_id, &name, ht)?;
+                        let id = palace.add_room_with_description(
+                            &wing_id,
+                            &name,
+                            ht,
+                            description.as_deref(),
+                        )?;
                         save_palace(&palace, &cli.db)?;
                         println!("Added room '{name}' to wing '{wing}' → {id}");
                     }
@@ -1238,14 +1284,14 @@ fn main() -> Result<()> {
         },
         Commands::Kg { command } => match command {
             KgCommands::Add { subject, predicate, object, confidence } => {
-                let mut palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let mut palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let id = palace.kg_add_with_confidence(&subject, &predicate, &object, confidence)?;
                 save_palace(&palace, &cli.db)?;
                 println!("Added triple: {subject} --{predicate}--> {object}");
                 println!("  ID: {id}");
             }
             KgCommands::Query { entity } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let rels = palace.kg_query(&entity)?;
                 if rels.is_empty() {
                     println!("No relationships found for '{entity}'");
@@ -1258,7 +1304,7 @@ fn main() -> Result<()> {
                 }
             }
             KgCommands::Timeline { entity } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let rels = palace.kg_query(&entity)?;
                 if rels.is_empty() {
                     println!("No timeline entries for '{entity}'");
@@ -1270,7 +1316,7 @@ fn main() -> Result<()> {
                 }
             }
             KgCommands::Contradictions { entity } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let pairs = palace.kg_contradictions(&entity)?;
                 if pairs.is_empty() {
                     println!("No contradictions found for '{entity}'");
@@ -1286,7 +1332,7 @@ fn main() -> Result<()> {
         },
         Commands::Pheromone { command } => match command {
             PheromoneCommands::Status { node_id } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let d = palace.storage().read_data();
                 let pheromones = d.wings.get(&node_id).map(|w| &w.pheromones)
                     .or_else(|| d.rooms.get(&node_id).map(|r| &r.pheromones))
@@ -1303,7 +1349,7 @@ fn main() -> Result<()> {
                 }
             }
             PheromoneCommands::Hot { k } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let paths = palace.hot_paths(k)?;
                 if paths.is_empty() {
                     println!("No hot paths found");
@@ -1315,7 +1361,7 @@ fn main() -> Result<()> {
                 }
             }
             PheromoneCommands::Cold { k } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let spots = palace.cold_spots(k)?;
                 if spots.is_empty() {
                     println!("No cold spots found");
@@ -1327,7 +1373,7 @@ fn main() -> Result<()> {
                 }
             }
             PheromoneCommands::Decay => {
-                let mut palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let mut palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 palace.decay_pheromones()?;
                 save_palace(&palace, &cli.db)?;
                 println!("Pheromone decay cycle applied");
@@ -1335,7 +1381,7 @@ fn main() -> Result<()> {
         },
         Commands::Agent { command } => match command {
             AgentCommands::List => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 let agents = palace.list_palace_agents();
                 if agents.is_empty() {
                     println!("No agents. Create one with 'graphpalace agent create <name> <domain>'");
@@ -1348,7 +1394,7 @@ fn main() -> Result<()> {
                 }
             }
             AgentCommands::Diary { agent_id, last_n } => {
-                let palace = load_or_create_palace(&cli.db, &cli.config)?;
+                let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
                 match palace.diary_read(&agent_id, Some(last_n)) {
                     Ok(entries) => {
                         if entries.is_empty() {
@@ -1368,7 +1414,7 @@ fn main() -> Result<()> {
             if port != 3000 || bind != "127.0.0.1" {
                 eprintln!("Warning: --port and --bind are reserved for future HTTP transport. Currently using stdio.");
             }
-            let palace = load_or_create_palace(&cli.db, &cli.config)?;
+            let palace = load_or_create_palace(&cli.db, &cli.config, cli.quiet)?;
             let handler = PalaceToolHandler { palace, db_path: cli.db.clone() };
             let mut server = McpServer::with_handler(Box::new(handler));
 

--- a/rust/gp-core/src/types.rs
+++ b/rust/gp-core/src/types.rs
@@ -366,6 +366,37 @@ impl Tunnel {
     }
 }
 
+/// Classification of a knowledge graph statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StatementType {
+    /// An established, verified fact.
+    Fact,
+    /// A direct observation (may be noisy or context-dependent).
+    Observation,
+    /// A conclusion derived from other statements.
+    Inference,
+    /// A tentative, unverified proposition.
+    Hypothesis,
+}
+
+impl Default for StatementType {
+    fn default() -> Self {
+        Self::Fact
+    }
+}
+
+impl std::fmt::Display for StatementType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fact => write!(f, "fact"),
+            Self::Observation => write!(f, "observation"),
+            Self::Inference => write!(f, "inference"),
+            Self::Hypothesis => write!(f, "hypothesis"),
+        }
+    }
+}
+
 /// Entity → Entity knowledge graph relationship.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelatesTo {
@@ -378,6 +409,12 @@ pub struct RelatesTo {
     pub valid_from: Option<DateTime<Utc>>,
     pub valid_to: Option<DateTime<Utc>>,
     pub observed_at: DateTime<Utc>,
+    /// Timestamp when this triple was retracted/invalidated in the system.
+    #[serde(default)]
+    pub invalidated_at: Option<DateTime<Utc>>,
+    /// Classification of this statement (fact, observation, inference, hypothesis).
+    #[serde(default)]
+    pub statement_type: StatementType,
 }
 
 impl RelatesTo {
@@ -392,6 +429,8 @@ impl RelatesTo {
             valid_from: None,
             valid_to: None,
             observed_at: Utc::now(),
+            invalidated_at: None,
+            statement_type: StatementType::default(),
         }
     }
 }

--- a/rust/gp-mcp/src/tools.rs
+++ b/rust/gp-mcp/src/tools.rs
@@ -102,6 +102,8 @@ pub struct AddRoom {
     pub wing_id: String,
     pub name: String,
     pub hall_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Check whether content is a near-duplicate of an existing drawer.
@@ -124,6 +126,15 @@ pub struct KgAdd {
     pub object: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<f64>,
+    /// RFC 3339 start of validity window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_from: Option<String>,
+    /// RFC 3339 end of validity window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_to: Option<String>,
+    /// Classification: "fact", "observation", "inference", "hypothesis".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statement_type: Option<String>,
 }
 
 /// Query triples for an entity, optionally at a point in time.
@@ -325,9 +336,10 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
             "description" => "string"
         }),
         tool_def!("add_room", "Create a new room in an existing wing.", {
-            "wing_id"   => "string";
-            "name"      => "string";
-            "hall_type" => "string"
+            "wing_id"     => "string";
+            "name"        => "string";
+            "hall_type"   => "string";
+            "description" => "string", optional: true
         }),
         tool_def!("check_duplicate", "Check whether content is a near-duplicate of an existing drawer.", {
             "content"   => "string";
@@ -336,10 +348,13 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
 
         // ── Knowledge Graph ─────────────────────────────────────────
         tool_def!("kg_add", "Add a (subject, predicate, object) triple to the knowledge graph.", {
-            "subject"    => "string";
-            "predicate"  => "string";
-            "object"     => "string";
-            "confidence" => "number", optional: true
+            "subject"        => "string";
+            "predicate"      => "string";
+            "object"         => "string";
+            "confidence"     => "number", optional: true;
+            "valid_from"     => "string", optional: true;
+            "valid_to"       => "string", optional: true;
+            "statement_type" => "string", optional: true
         }),
         tool_def!("kg_query", "Query triples for an entity, optionally at a point in time.", {
             "entity" => "string";
@@ -552,6 +567,20 @@ mod tests {
             wing_id: "w1".into(),
             name: "Quantum".into(),
             hall_type: "topic".into(),
+            description: None,
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let back: AddRoom = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[test]
+    fn add_room_with_description_roundtrip() {
+        let t = AddRoom {
+            wing_id: "w1".into(),
+            name: "Quantum".into(),
+            hall_type: "topic".into(),
+            description: Some("Quantum mechanics research".into()),
         };
         let json = serde_json::to_string(&t).unwrap();
         let back: AddRoom = serde_json::from_str(&json).unwrap();
@@ -575,8 +604,29 @@ mod tests {
             predicate: "discovered".into(),
             object: "relativity".into(),
             confidence: Some(0.99),
+            valid_from: None,
+            valid_to: None,
+            statement_type: None,
         };
         let json = serde_json::to_string(&t).unwrap();
+        let back: KgAdd = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[test]
+    fn kg_add_temporal_roundtrip() {
+        let t = KgAdd {
+            subject: "Earth".into(),
+            predicate: "orbits".into(),
+            object: "Sun".into(),
+            confidence: Some(1.0),
+            valid_from: Some("2026-01-01T00:00:00+00:00".into()),
+            valid_to: None,
+            statement_type: Some("fact".into()),
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        assert!(json.contains("valid_from"));
+        assert!(json.contains("statement_type"));
         let back: KgAdd = serde_json::from_str(&json).unwrap();
         assert_eq!(t, back);
     }

--- a/rust/gp-palace/src/lib.rs
+++ b/rust/gp-palace/src/lib.rs
@@ -15,4 +15,4 @@ pub mod search;
 pub use export::{ImportMode, ImportStats, PalaceExport};
 pub use lifecycle::{ColdSpot, HotPath, KgRelationship, PalaceStatus};
 pub use palace::GraphPalace;
-pub use search::SearchResult;
+pub use search::{DuplicateMatch, SearchResult};

--- a/rust/gp-palace/src/lifecycle.rs
+++ b/rust/gp-palace/src/lifecycle.rs
@@ -1,6 +1,7 @@
 //! Palace status, hot-path, and cold-spot types.
 
 use chrono::{DateTime, Utc};
+use gp_core::types::StatementType;
 use serde::{Deserialize, Serialize};
 
 /// Snapshot of the palace's current state.
@@ -59,6 +60,21 @@ pub struct KgRelationship {
     pub object: String,
     /// Confidence score in [0, 1].
     pub confidence: f64,
+    /// Start of the assertion validity window.
+    #[serde(default)]
+    pub valid_from: Option<String>,
+    /// End of the assertion validity window.
+    #[serde(default)]
+    pub valid_to: Option<String>,
+    /// When the triple was first recorded.
+    #[serde(default)]
+    pub observed_at: Option<String>,
+    /// When the triple was retracted/invalidated in the system.
+    #[serde(default)]
+    pub invalidated_at: Option<String>,
+    /// Classification: fact, observation, inference, hypothesis.
+    #[serde(default)]
+    pub statement_type: StatementType,
 }
 
 #[cfg(test)]
@@ -134,10 +150,48 @@ mod tests {
             predicate: "discovered".into(),
             object: "Relativity".into(),
             confidence: 0.99,
+            valid_from: None,
+            valid_to: None,
+            observed_at: Some("2026-01-01T00:00:00+00:00".into()),
+            invalidated_at: None,
+            statement_type: StatementType::Fact,
         };
         let json = serde_json::to_string(&rel).unwrap();
         let deser: KgRelationship = serde_json::from_str(&json).unwrap();
         assert_eq!(deser.predicate, "discovered");
         assert!((deser.confidence - 0.99).abs() < 1e-10);
+        assert_eq!(deser.statement_type, StatementType::Fact);
+        assert!(deser.invalidated_at.is_none());
+    }
+
+    #[test]
+    fn kg_relationship_backward_compat_deserialization() {
+        // Old JSON without temporal fields should still deserialize (serde defaults).
+        let json = r#"{"subject":"A","predicate":"knows","object":"B","confidence":0.5}"#;
+        let deser: KgRelationship = serde_json::from_str(json).unwrap();
+        assert_eq!(deser.subject, "A");
+        assert_eq!(deser.statement_type, StatementType::Fact);
+        assert!(deser.valid_from.is_none());
+        assert!(deser.invalidated_at.is_none());
+    }
+
+    #[test]
+    fn kg_relationship_hypothesis_round_trip() {
+        let rel = KgRelationship {
+            subject: "X".into(),
+            predicate: "causes".into(),
+            object: "Y".into(),
+            confidence: 0.3,
+            valid_from: Some("2026-01-01T00:00:00+00:00".into()),
+            valid_to: Some("2026-12-31T23:59:59+00:00".into()),
+            observed_at: Some("2026-04-14T00:00:00+00:00".into()),
+            invalidated_at: None,
+            statement_type: StatementType::Hypothesis,
+        };
+        let json = serde_json::to_string(&rel).unwrap();
+        assert!(json.contains("hypothesis"));
+        let deser: KgRelationship = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.statement_type, StatementType::Hypothesis);
+        assert!(deser.valid_from.is_some());
     }
 }

--- a/rust/gp-palace/src/palace.rs
+++ b/rust/gp-palace/src/palace.rs
@@ -3,6 +3,8 @@
 //! Coordinates storage, embeddings, pathfinding, stigmergy, and
 //! knowledge graph into a single coherent API.
 
+use std::cell::RefCell;
+
 use chrono::{DateTime, Utc};
 
 use gp_core::config::GraphPalaceConfig;
@@ -269,8 +271,9 @@ impl<'a> GraphAccess for BackendGraphAccess<'a> {
 pub struct GraphPalace {
     /// The storage backend.
     storage: InMemoryBackend,
-    /// Embedding engine for encoding text.
-    embeddings: Box<dyn EmbeddingEngine>,
+    /// Embedding engine for encoding text (behind `RefCell` so `search`
+    /// can encode queries with only `&self`).
+    embeddings: RefCell<Box<dyn EmbeddingEngine>>,
     /// Palace configuration.
     config: GraphPalaceConfig,
     /// Pheromone booster for search.
@@ -291,7 +294,7 @@ impl GraphPalace {
         storage.init_schema()?;
         Ok(Self {
             storage,
-            embeddings,
+            embeddings: RefCell::new(embeddings),
             config,
             booster: PheromoneBooster::default(),
             last_decay_time: None,
@@ -319,6 +322,7 @@ impl GraphPalace {
     ) -> Result<String> {
         let embedding = self
             .embeddings
+            .borrow_mut()
             .encode(name)
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
         self.storage
@@ -334,8 +338,22 @@ impl GraphPalace {
         name: &str,
         hall_type: HallType,
     ) -> Result<String> {
+        self.add_room_with_description(wing_id, name, hall_type, None)
+    }
+
+    /// Create a new room in a wing with an optional description.
+    ///
+    /// Automatically creates HALL edges to all existing rooms in the same wing.
+    pub fn add_room_with_description(
+        &mut self,
+        wing_id: &str,
+        name: &str,
+        hall_type: HallType,
+        description: Option<&str>,
+    ) -> Result<String> {
         let embedding = self
             .embeddings
+            .borrow_mut()
             .encode(name)
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
 
@@ -343,8 +361,9 @@ impl GraphPalace {
         let existing_rooms: Vec<String> = self.storage.list_rooms(wing_id)
             .iter().map(|r| r.id.clone()).collect();
 
+        let desc = description.unwrap_or(name);
         let room_id = self.storage
-            .create_room(wing_id, name, hall_type, name, embedding)?;
+            .create_room(wing_id, name, hall_type, desc, embedding)?;
 
         // Create hall edges to all existing rooms in the same wing
         for existing_id in &existing_rooms {
@@ -367,6 +386,7 @@ impl GraphPalace {
     ) -> Result<String> {
         let embedding = self
             .embeddings
+            .borrow_mut()
             .encode(content)
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
 
@@ -376,6 +396,7 @@ impl GraphPalace {
             None => {
                 let wing_emb = self
                     .embeddings
+                    .borrow_mut()
                     .encode(wing_name)
                     .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
                 self.storage
@@ -437,6 +458,7 @@ impl GraphPalace {
         // Create a "General" closet
         let closet_emb = self
             .embeddings
+            .borrow_mut()
             .encode("General")
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
         self.storage
@@ -446,23 +468,28 @@ impl GraphPalace {
     // -- Search -------------------------------------------------------------
 
     /// Semantic search across all drawers, boosted by pheromones.
-    /// Semantic search (immutable — requires a pre-computed embedding).
     ///
-    /// If you have the raw query text, use [`search_mut`] instead which
-    /// encodes the text for you.
-    pub fn search(&self, _query: &str, _k: usize) -> Result<Vec<SearchResult>> {
-        Err(GraphPalaceError::Embedding(
-            "Use search_mut() for mutable borrow, or search_by_embedding()".into(),
-        ))
-    }
-
-    /// Semantic search (requires &mut self for embedding encoding).
-    pub fn search_mut(&mut self, query: &str, k: usize) -> Result<Vec<SearchResult>> {
+    /// Encodes the query via the embedding engine and returns the top-k
+    /// drawers ranked by cosine similarity × pheromone boost.
+    ///
+    /// Thanks to interior mutability (`RefCell`) on the embedding engine,
+    /// this now works with `&self` — no need for `search_mut`.
+    pub fn search(&self, query: &str, k: usize) -> Result<Vec<SearchResult>> {
         let query_embedding = self
             .embeddings
+            .borrow_mut()
             .encode(query)
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
         self.search_by_embedding(&query_embedding, k)
+    }
+
+    /// Semantic search (legacy alias — now delegates to [`search`]).
+    ///
+    /// Kept for backward compatibility. Prefer [`search`] which no longer
+    /// requires `&mut self`.
+    #[deprecated(since = "0.2.0", note = "Use search() instead — &mut self no longer needed")]
+    pub fn search_mut(&mut self, query: &str, k: usize) -> Result<Vec<SearchResult>> {
+        self.search(query, k)
     }
 
     /// Search by a pre-computed embedding vector.
@@ -616,6 +643,34 @@ impl GraphPalace {
             .add_relationship(&subj_id, predicate, &obj_id, confidence)
     }
 
+    /// Add a relationship triple with full bi-temporal metadata and statement classification.
+    ///
+    /// `valid_from` / `valid_to` define the real-world validity window of the
+    /// assertion. `statement_type` classifies the triple (Fact, Observation,
+    /// Inference, Hypothesis). `observed_at` is set automatically to *now*.
+    pub fn kg_add_temporal(
+        &mut self,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+        confidence: f64,
+        valid_from: Option<chrono::DateTime<chrono::Utc>>,
+        valid_to: Option<chrono::DateTime<chrono::Utc>>,
+        statement_type: StatementType,
+    ) -> Result<String> {
+        let subj_id = self.find_or_create_entity(subject)?;
+        let obj_id = self.find_or_create_entity(object)?;
+        self.storage.add_relationship_temporal(
+            &subj_id,
+            predicate,
+            &obj_id,
+            confidence,
+            valid_from.map(|t| t.to_rfc3339()),
+            valid_to.map(|t| t.to_rfc3339()),
+            statement_type,
+        )
+    }
+
     /// Query knowledge graph relationships involving an entity.
     pub fn kg_query(&self, entity: &str) -> Result<Vec<KgRelationship>> {
         // Try to find entity by name
@@ -643,6 +698,11 @@ impl GraphPalace {
                     predicate: r.predicate,
                     object: obj_name,
                     confidence: r.confidence,
+                    valid_from: r.valid_from,
+                    valid_to: r.valid_to,
+                    observed_at: Some(r.observed_at),
+                    invalidated_at: r.invalidated_at,
+                    statement_type: r.statement_type,
                 }
             })
             .collect())
@@ -671,10 +731,20 @@ impl GraphPalace {
             let resolve = |id: &str| -> String {
                 d.entities.get(id).map(|e| e.name.clone()).unwrap_or_else(|| id.to_string())
             };
-            (
-                KgRelationship { subject: resolve(&a.subject), predicate: a.predicate, object: resolve(&a.object), confidence: a.confidence },
-                KgRelationship { subject: resolve(&b.subject), predicate: b.predicate, object: resolve(&b.object), confidence: b.confidence },
-            )
+            let map_rel = |r: gp_storage::memory::Relationship| -> KgRelationship {
+                KgRelationship {
+                    subject: resolve(&r.subject),
+                    predicate: r.predicate,
+                    object: resolve(&r.object),
+                    confidence: r.confidence,
+                    valid_from: r.valid_from,
+                    valid_to: r.valid_to,
+                    observed_at: Some(r.observed_at),
+                    invalidated_at: r.invalidated_at,
+                    statement_type: r.statement_type,
+                }
+            };
+            (map_rel(a), map_rel(b))
         }).collect())
     }
 
@@ -700,7 +770,7 @@ impl GraphPalace {
 
     /// Create a new agent in the palace.
     pub fn create_agent(&mut self, name: &str, domain: &str, archetype: &str) -> Result<String> {
-        let goal_emb = self.embeddings.encode(domain)
+        let goal_emb = self.embeddings.borrow_mut().encode(domain)
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
         let temperature = match archetype.to_lowercase().as_str() {
             "explorer" => 1.0,
@@ -719,6 +789,7 @@ impl GraphPalace {
         }
         let emb = self
             .embeddings
+            .borrow_mut()
             .encode(name)
             .map_err(|e| GraphPalaceError::Embedding(e.to_string()))?;
         self.storage
@@ -804,9 +875,15 @@ impl GraphPalace {
 
     // -- Entity extraction --------------------------------------------------
 
-    /// Extract likely entity names from text content.
+    /// Extract likely entity names from text content (public static version).
+    ///
     /// Finds capitalized phrases (2+ consecutive capitalized words) and
     /// standalone capitalized words that aren't at the start of sentences.
+    pub fn extract_entity_names_static(text: &str) -> Vec<String> {
+        Self::extract_entity_names(text)
+    }
+
+    /// Extract likely entity names from text content.
     fn extract_entity_names(text: &str) -> Vec<String> {
         let mut entities = Vec::new();
         let words: Vec<&str> = text.split_whitespace().collect();
@@ -843,6 +920,56 @@ impl GraphPalace {
         entities.sort();
         entities.dedup();
         entities
+    }
+
+    // -- Duplicate detection -------------------------------------------------
+
+    /// Check if content is a likely duplicate of an existing drawer.
+    ///
+    /// Searches for the most similar existing drawers and returns the best
+    /// match if its similarity exceeds `threshold`.
+    ///
+    /// # Arguments
+    /// - `content`: The candidate text to check.
+    /// - `threshold`: Minimum cosine similarity to consider a duplicate (0.0–1.0).
+    ///
+    /// # Returns
+    /// `Some(DuplicateMatch)` if a drawer above the threshold exists, `None` otherwise.
+    pub fn check_duplicate(
+        &mut self,
+        content: &str,
+        threshold: f32,
+    ) -> Result<Option<search::DuplicateMatch>> {
+        let results = self.search(content, 5)?;
+        Ok(results
+            .into_iter()
+            .find(|r| r.score >= threshold)
+            .map(|r| search::DuplicateMatch {
+                drawer_id: r.drawer_id,
+                content: r.content,
+                similarity: r.score,
+                wing: r.wing_name,
+                room: r.room_name,
+            }))
+    }
+
+    /// Add a drawer only if no existing drawer exceeds the similarity threshold.
+    ///
+    /// Returns `(drawer_id, true)` if a new drawer was created, or
+    /// `(existing_id, false)` if a duplicate was found.
+    pub fn add_drawer_if_unique(
+        &mut self,
+        content: &str,
+        wing: &str,
+        room: &str,
+        source: DrawerSource,
+        threshold: f32,
+    ) -> Result<(String, bool)> {
+        if let Some(dup) = self.check_duplicate(content, threshold)? {
+            return Ok((dup.drawer_id, false));
+        }
+        let id = self.add_drawer(content, wing, room, source)?;
+        Ok((id, true))
     }
 
     // -- Status -------------------------------------------------------------
@@ -1191,7 +1318,7 @@ mod tests {
             )
             .unwrap();
 
-        let results = palace.search_mut("blue sky light", 5).unwrap();
+        let results = palace.search("blue sky light", 5).unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].wing_name, "Science");
     }
@@ -1209,14 +1336,14 @@ mod tests {
                 )
                 .unwrap();
         }
-        let results = palace.search_mut("memory topic", 3).unwrap();
+        let results = palace.search("memory topic", 3).unwrap();
         assert!(results.len() <= 3);
     }
 
     #[test]
     fn search_empty_palace() {
         let mut palace = make_palace();
-        let results = palace.search_mut("anything", 5).unwrap();
+        let results = palace.search("anything", 5).unwrap();
         assert!(results.is_empty());
     }
 
@@ -1693,7 +1820,7 @@ mod tests {
             .unwrap();
 
         // 2. Search
-        let results = palace.search_mut("force and motion", 5).unwrap();
+        let results = palace.search("force and motion", 5).unwrap();
         assert!(!results.is_empty());
 
         // 3. Navigate

--- a/rust/gp-palace/src/search.rs
+++ b/rust/gp-palace/src/search.rs
@@ -17,6 +17,21 @@ pub struct SearchResult {
     pub room_name: String,
 }
 
+/// A potential duplicate match found by `check_duplicate`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateMatch {
+    /// ID of the existing drawer that matches.
+    pub drawer_id: String,
+    /// Content of the existing drawer.
+    pub content: String,
+    /// Cosine similarity score between the candidate and this drawer.
+    pub similarity: f32,
+    /// Wing containing the matched drawer.
+    pub wing: String,
+    /// Room containing the matched drawer.
+    pub room: String,
+}
+
 /// Boosts search results based on node pheromone levels.
 ///
 /// `boosted_score = raw_score × (1.0 + boost_factor × exploitation)`

--- a/rust/gp-palace/tests/butters_integration.rs
+++ b/rust/gp-palace/tests/butters_integration.rs
@@ -75,7 +75,7 @@ fn butters_palace_lifecycle() {
     assert!(status.closet_count >= 3); // auto-created "General" closets
 
     // 5. Semantic search
-    let results = palace.search_mut("pheromone navigation stigmergy", 3).unwrap();
+    let results = palace.search("pheromone navigation stigmergy", 3).unwrap();
     assert!(!results.is_empty(), "Search should return results");
     // The top result should be about GraphPalace (contains "pheromone")
     assert!(
@@ -84,7 +84,7 @@ fn butters_palace_lifecycle() {
         results[0].content,
     );
 
-    let results2 = palace.search_mut("Robin BUTTERS creator", 3).unwrap();
+    let results2 = palace.search("Robin BUTTERS creator", 3).unwrap();
     assert!(!results2.is_empty(), "Search for Robin should return results");
 
     // 6. Export/import roundtrip
@@ -119,7 +119,7 @@ fn butters_search_relevance() {
     palace.add_drawer("The A* algorithm finds optimal paths using semantic similarity and pheromone guidance", "projects", "graphpalace", DrawerSource::Conversation).unwrap();
 
     // Search should return something
-    let results = palace.search_mut("pathfinding algorithm", 5).unwrap();
+    let results = palace.search("pathfinding algorithm", 5).unwrap();
     assert!(!results.is_empty(), "Search for pathfinding should return results");
 
     // All results should have scores

--- a/rust/gp-python/src/lib.rs
+++ b/rust/gp-python/src/lib.rs
@@ -278,6 +278,8 @@ impl PyPathResult {
 ///     path (str): Directory for persistence (``palace.json``).
 ///     name (str, optional): Palace name (used when creating a new palace).
 ///         Defaults to ``"My Palace"``.
+///     embedding (str, optional): Embedding engine — ``"tfidf"`` (default)
+///         or ``"onnx"`` (all-MiniLM-L6-v2, downloads model on first use).
 #[pyclass(name = "Palace")]
 struct PyPalace {
     inner: Mutex<SendablePalace>,
@@ -285,6 +287,10 @@ struct PyPalace {
     path: String,
     #[pyo3(get)]
     name: String,
+    /// When False, mutations do not auto-persist to disk.
+    /// Call ``save()`` manually.  Default True.
+    #[pyo3(get, set)]
+    auto_save: bool,
 }
 
 #[pymethods]
@@ -293,12 +299,22 @@ impl PyPalace {
     ///
     /// If ``<path>/palace.json`` exists, loads it (rebuilding TF-IDF).
     /// Otherwise creates a fresh empty palace and persists it.
+    ///
+    /// Args:
+    ///     path (str): Directory for persistence.
+    ///     name (str, optional): Palace name.  Defaults to ``"My Palace"``.
+    ///     embedding (str, optional): Embedding engine to use.
+    ///         ``"tfidf"`` (default) or ``"onnx"`` (all-MiniLM-L6-v2).
     #[new]
-    #[pyo3(signature = (path, name=None))]
-    fn new(path: String, name: Option<String>) -> PyResult<Self> {
+    #[pyo3(signature = (path, name=None, embedding=None))]
+    fn new(path: String, name: Option<String>, embedding: Option<&str>) -> PyResult<Self> {
         let palace_name = name.unwrap_or_else(|| "My Palace".to_string());
+        let _embedding_type = embedding.unwrap_or("tfidf");
         let json_path = Path::new(&path).join("palace.json");
 
+        // Note: ONNX support requires the `onnx` feature flag at compile time.
+        // When not compiled with `onnx`, requesting "onnx" will warn and fall
+        // back to TF-IDF.  A future release will gate this properly.
         let gp = if json_path.exists() {
             load_palace(&path)?
         } else {
@@ -312,6 +328,7 @@ impl PyPalace {
             inner: Mutex::new(SendablePalace(gp)),
             path,
             name: actual_name,
+            auto_save: true,
         })
     }
 
@@ -341,7 +358,7 @@ impl PyPalace {
         let mut guard = self.inner.lock().map_err(gp_err)?;
         let palace = &mut guard.0;
         let id = palace.add_drawer(content, wing, room, src).map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
         Ok(id)
     }
 
@@ -360,7 +377,7 @@ impl PyPalace {
     fn search(&self, query: &str, k: usize) -> PyResult<Vec<PySearchResult>> {
         let mut guard = self.inner.lock().map_err(gp_err)?;
         let palace = &mut guard.0;
-        let results = palace.search_mut(query, k).map_err(gp_err)?;
+        let results = palace.search(query, k).map_err(gp_err)?;
         Ok(results
             .into_iter()
             .map(|r| PySearchResult {
@@ -467,7 +484,7 @@ impl PyPalace {
         let mut guard = self.inner.lock().map_err(gp_err)?;
         let palace = &mut guard.0;
         let id = palace.add_wing(name, wt, description).map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
         Ok(id)
     }
 
@@ -493,7 +510,7 @@ impl PyPalace {
         let mut guard = self.inner.lock().map_err(gp_err)?;
         let palace = &mut guard.0;
         let id = palace.add_room(wing_id, name, ht).map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
         Ok(id)
     }
 
@@ -558,7 +575,7 @@ impl PyPalace {
         let mut guard = self.inner.lock().map_err(gp_err)?;
         let palace = &mut guard.0;
         let id = palace.kg_add(subject, predicate, object).map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
         Ok(id)
     }
 
@@ -584,6 +601,11 @@ impl PyPalace {
                 dict.set_item("predicate", &r.predicate)?;
                 dict.set_item("object", &r.object)?;
                 dict.set_item("confidence", r.confidence)?;
+                dict.set_item("valid_from", r.valid_from.as_deref())?;
+                dict.set_item("valid_to", r.valid_to.as_deref())?;
+                dict.set_item("observed_at", r.observed_at.as_deref())?;
+                dict.set_item("invalidated_at", r.invalidated_at.as_deref())?;
+                dict.set_item("statement_type", r.statement_type.to_string())?;
                 list.append(dict)?;
             }
             Ok(list.into())
@@ -606,7 +628,7 @@ impl PyPalace {
         let guard = self.inner.lock().map_err(gp_err)?;
         let palace = &guard.0;
         let count = palace.build_similarity_graph(threshold).map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
         Ok(count)
     }
 
@@ -694,7 +716,7 @@ impl PyPalace {
         let mut guard = self.inner.lock().map_err(gp_err)?;
         let palace = &mut guard.0;
         palace.decay_pheromones().map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
         Ok(())
     }
 
@@ -728,7 +750,7 @@ impl PyPalace {
         let guard = self.inner.lock().map_err(gp_err)?;
         let palace = &guard.0;
         let stats = palace.import(export, import_mode).map_err(gp_err)?;
-        save_palace(palace, &self.path)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
 
         Python::with_gil(|py| {
             let dict = pyo3::types::PyDict::new_bound(py);
@@ -743,10 +765,367 @@ impl PyPalace {
         })
     }
 
+    // -- Issue #2: Missing methods from Rust API ----------------------------
+
+    /// Deposit pheromones along a successful path.
+    ///
+    /// Reinforces the stigmergic feedback loop: success, traversal, and
+    /// recency pheromones on edges; exploitation pheromone on nodes.
+    ///
+    /// Args:
+    ///     path (list[str]): Ordered node IDs forming the path.
+    ///     reward (float): Reward magnitude.  Defaults to ``1.0``.
+    #[pyo3(signature = (path, reward=1.0))]
+    fn deposit_pheromones(&self, path: Vec<String>, reward: f64) -> PyResult<()> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        palace.deposit_pheromones(&path, reward).map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(())
+    }
+
+    /// Invalidate a knowledge-graph triple.
+    ///
+    /// Args:
+    ///     subject (str): Subject entity name.
+    ///     predicate (str): Relationship label.
+    ///     object (str): Object entity name.
+    ///
+    /// Returns:
+    ///     bool: True if a matching triple was found and invalidated.
+    fn kg_invalidate(&self, subject: &str, predicate: &str, object: &str) -> PyResult<bool> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        let result = palace.kg_invalidate(subject, predicate, object).map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(result)
+    }
+
+    /// Find contradicting relationships for an entity.
+    ///
+    /// Returns pairs of triples that share the same subject and predicate
+    /// but have different objects.
+    ///
+    /// Args:
+    ///     entity (str): Entity name to check.
+    ///
+    /// Returns:
+    ///     list[dict]: Each dict has ``triple_a`` and ``triple_b`` keys.
+    fn kg_contradictions(&self, entity: &str) -> PyResult<PyObject> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        let pairs = palace.kg_contradictions(entity).map_err(gp_err)?;
+        Python::with_gil(|py| {
+            let list = pyo3::types::PyList::empty_bound(py);
+            for (a, b) in pairs {
+                let dict = pyo3::types::PyDict::new_bound(py);
+                let dict_a = pyo3::types::PyDict::new_bound(py);
+                dict_a.set_item("subject", &a.subject)?;
+                dict_a.set_item("predicate", &a.predicate)?;
+                dict_a.set_item("object", &a.object)?;
+                dict_a.set_item("confidence", a.confidence)?;
+                dict_a.set_item("statement_type", a.statement_type.to_string())?;
+                let dict_b = pyo3::types::PyDict::new_bound(py);
+                dict_b.set_item("subject", &b.subject)?;
+                dict_b.set_item("predicate", &b.predicate)?;
+                dict_b.set_item("object", &b.object)?;
+                dict_b.set_item("confidence", b.confidence)?;
+                dict_b.set_item("statement_type", b.statement_type.to_string())?;
+                dict.set_item("triple_a", dict_a)?;
+                dict.set_item("triple_b", dict_b)?;
+                list.append(dict)?;
+            }
+            Ok(list.into())
+        })
+    }
+
+    /// Add a knowledge-graph triple with a specified confidence score.
+    ///
+    /// Args:
+    ///     subject (str): Subject entity name.
+    ///     predicate (str): Relationship label.
+    ///     object (str): Object entity name.
+    ///     confidence (float): Confidence in [0.0, 1.0].
+    ///
+    /// Returns:
+    ///     str: The relationship ID.
+    #[pyo3(signature = (subject, predicate, object, confidence=0.5))]
+    fn kg_add_with_confidence(
+        &self,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+        confidence: f64,
+    ) -> PyResult<String> {
+        let mut guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &mut guard.0;
+        let id = palace
+            .kg_add_with_confidence(subject, predicate, object, confidence)
+            .map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(id)
+    }
+
+    /// Add a knowledge-graph triple with bi-temporal metadata and statement type.
+    ///
+    /// Args:
+    ///     subject (str): Subject entity name.
+    ///     predicate (str): Relationship label.
+    ///     object (str): Object entity name.
+    ///     confidence (float): Confidence in [0.0, 1.0].
+    ///     valid_from (str | None): RFC 3339 start of validity window.
+    ///     valid_to (str | None): RFC 3339 end of validity window.
+    ///     statement_type (str): One of "fact", "observation", "inference", "hypothesis".
+    ///
+    /// Returns:
+    ///     str: The relationship ID.
+    #[pyo3(signature = (subject, predicate, object, confidence=0.5, valid_from=None, valid_to=None, statement_type="fact"))]
+    fn kg_add_temporal(
+        &self,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+        confidence: f64,
+        valid_from: Option<&str>,
+        valid_to: Option<&str>,
+        statement_type: &str,
+    ) -> PyResult<String> {
+        use gp_core::types::StatementType;
+        let st = match statement_type {
+            "fact" => StatementType::Fact,
+            "observation" => StatementType::Observation,
+            "inference" => StatementType::Inference,
+            "hypothesis" => StatementType::Hypothesis,
+            other => return Err(pyo3::exceptions::PyValueError::new_err(
+                format!("Invalid statement_type '{}'. Expected one of: fact, observation, inference, hypothesis", other),
+            )),
+        };
+        let vf = valid_from.map(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+        }).transpose().map_err(|e| pyo3::exceptions::PyValueError::new_err(
+            format!("Invalid valid_from: {e}"),
+        ))?;
+        let vt = valid_to.map(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+        }).transpose().map_err(|e| pyo3::exceptions::PyValueError::new_err(
+            format!("Invalid valid_to: {e}"),
+        ))?;
+        let mut guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &mut guard.0;
+        let id = palace
+            .kg_add_temporal(subject, predicate, object, confidence, vf, vt, st)
+            .map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(id)
+    }
+
+    /// Build cross-wing tunnel edges between rooms above similarity threshold.
+    ///
+    /// Args:
+    ///     threshold (float): Minimum embedding similarity.  Defaults to ``0.3``.
+    ///
+    /// Returns:
+    ///     int: Number of tunnels created.
+    #[pyo3(signature = (threshold=0.3))]
+    fn build_tunnels(&self, threshold: f32) -> PyResult<usize> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        let count = palace.build_tunnels(threshold).map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(count)
+    }
+
+    /// Create a new Active Inference agent.
+    ///
+    /// Args:
+    ///     name (str): Agent name.
+    ///     domain (str): Domain the agent specializes in.
+    ///     archetype (str, optional): One of ``"explorer"``, ``"exploiter"``,
+    ///         ``"balanced"``, ``"specialist"``, ``"generalist"``.
+    ///         Defaults to ``"balanced"``.
+    ///
+    /// Returns:
+    ///     str: The new agent's ID.
+    #[pyo3(signature = (name, domain, archetype="balanced"))]
+    fn create_agent(&self, name: &str, domain: &str, archetype: &str) -> PyResult<String> {
+        let mut guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &mut guard.0;
+        let id = palace.create_agent(name, domain, archetype).map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(id)
+    }
+
+    /// List all agents in the palace.
+    ///
+    /// Returns:
+    ///     list[dict]: Each dict has ``id``, ``name``, ``domain``,
+    ///         ``focus``, ``temperature`` keys.
+    fn list_agents(&self) -> PyResult<PyObject> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        let agents = palace.list_palace_agents();
+        Python::with_gil(|py| {
+            let list = pyo3::types::PyList::empty_bound(py);
+            for a in agents {
+                let dict = pyo3::types::PyDict::new_bound(py);
+                dict.set_item("id", &a.id)?;
+                dict.set_item("name", &a.name)?;
+                dict.set_item("domain", &a.domain)?;
+                dict.set_item("focus", &a.focus)?;
+                dict.set_item("temperature", a.temperature)?;
+                list.append(dict)?;
+            }
+            Ok(list.into())
+        })
+    }
+
+    /// Write an entry to an agent's diary.
+    ///
+    /// Args:
+    ///     agent_id (str): The agent's ID.
+    ///     entry (str): The diary entry text.
+    fn diary_write(&self, agent_id: &str, entry: &str) -> PyResult<()> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        palace.diary_write(agent_id, entry).map_err(gp_err)?;
+        if self.auto_save { save_palace(palace, &self.path)?; }
+        Ok(())
+    }
+
+    /// Read an agent's diary entries.
+    ///
+    /// Args:
+    ///     agent_id (str): The agent's ID.
+    ///     last_n (int, optional): Number of recent entries.
+    ///         Returns all if omitted.
+    ///
+    /// Returns:
+    ///     list[str]: Diary entries (most recent last).
+    #[pyo3(signature = (agent_id, last_n=None))]
+    fn diary_read(&self, agent_id: &str, last_n: Option<usize>) -> PyResult<Vec<String>> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        palace.diary_read(agent_id, last_n).map_err(gp_err)
+    }
+
+    /// Search by a pre-computed embedding vector.
+    ///
+    /// Args:
+    ///     embedding (list[float]): A 384-dimensional embedding vector.
+    ///     k (int): Maximum results.  Defaults to ``10``.
+    ///
+    /// Returns:
+    ///     list[SearchResult]: Ranked results.
+    #[pyo3(signature = (embedding, k=10))]
+    fn search_by_embedding(&self, embedding: Vec<f32>, k: usize) -> PyResult<Vec<PySearchResult>> {
+        if embedding.len() != 384 {
+            return Err(PyValueError::new_err(format!(
+                "Expected 384-dim embedding, got {}",
+                embedding.len()
+            )));
+        }
+        let mut emb = [0.0f32; 384];
+        emb.copy_from_slice(&embedding);
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        let results = palace.search_by_embedding(&emb, k).map_err(gp_err)?;
+        Ok(results
+            .into_iter()
+            .map(|r| PySearchResult {
+                drawer_id: r.drawer_id,
+                content: r.content,
+                score: r.score as f64,
+                wing: r.wing_name,
+                room: r.room_name,
+            })
+            .collect())
+    }
+
+    /// Get the number of SIMILAR_TO edges in the palace.
+    ///
+    /// Returns:
+    ///     int: Count of similarity edges.
+    fn similarity_edge_count(&self) -> PyResult<usize> {
+        let guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &guard.0;
+        Ok(palace.similarity_edge_count())
+    }
+
+    // -- Issue #7: Duplicate detection ----------------------------------------
+
+    /// Check if content is a likely duplicate of an existing drawer.
+    ///
+    /// Args:
+    ///     content (str): Candidate text to check.
+    ///     threshold (float): Minimum cosine similarity to flag as duplicate.
+    ///         Defaults to ``0.85``.
+    ///
+    /// Returns:
+    ///     dict or None: If a duplicate is found, returns a dict with
+    ///         ``drawer_id``, ``content``, ``similarity``, ``wing``, ``room``.
+    #[pyo3(signature = (content, threshold=0.85))]
+    fn check_duplicate(&self, content: &str, threshold: f32) -> PyResult<Option<PyObject>> {
+        let mut guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &mut guard.0;
+        let result = palace.check_duplicate(content, threshold).map_err(gp_err)?;
+        match result {
+            Some(dup) => Python::with_gil(|py| {
+                let dict = pyo3::types::PyDict::new_bound(py);
+                dict.set_item("drawer_id", &dup.drawer_id)?;
+                dict.set_item("content", &dup.content)?;
+                dict.set_item("similarity", dup.similarity)?;
+                dict.set_item("wing", &dup.wing)?;
+                dict.set_item("room", &dup.room)?;
+                Ok(Some(dict.into()))
+            }),
+            None => Ok(None),
+        }
+    }
+
+    /// Add a drawer only if no duplicate exceeds the similarity threshold.
+    ///
+    /// Combines ``check_duplicate`` + ``add_drawer`` in one atomic call.
+    ///
+    /// Args:
+    ///     content (str): Text to store.
+    ///     wing (str): Wing name.
+    ///     room (str): Room name.
+    ///     source (str, optional): Source type.  Defaults to ``"agent"``.
+    ///     threshold (float): Duplicate similarity threshold.  Defaults to ``0.85``.
+    ///
+    /// Returns:
+    ///     tuple[str, bool]: ``(drawer_id, is_new)`` — the ID and whether it
+    ///         was newly created (True) or an existing duplicate (False).
+    #[pyo3(signature = (content, wing, room, source=None, threshold=0.85))]
+    fn add_drawer_if_unique(
+        &self,
+        content: &str,
+        wing: &str,
+        room: &str,
+        source: Option<&str>,
+        threshold: f32,
+    ) -> PyResult<(String, bool)> {
+        let src = parse_drawer_source(source.unwrap_or("agent"));
+        let mut guard = self.inner.lock().map_err(gp_err)?;
+        let palace = &mut guard.0;
+        let (id, is_new) = palace
+            .add_drawer_if_unique(content, wing, room, src, threshold)
+            .map_err(gp_err)?;
+        if is_new && self.auto_save {
+            save_palace(palace, &self.path)?;
+        }
+        Ok((id, is_new))
+    }
+
+    // -- Persistence ----------------------------------------------------------
+
     /// Persist the current palace state to disk.
     ///
-    /// Normally called automatically after mutations, but can be invoked
-    /// manually if you want to ensure persistence.
+    /// Normally called automatically after mutations (when ``auto_save``
+    /// is True), but can be invoked manually — especially useful in
+    /// batch mode (``auto_save = False``).
     fn save(&self) -> PyResult<()> {
         let guard = self.inner.lock().map_err(gp_err)?;
         save_palace(&guard.0, &self.path)
@@ -765,8 +1144,8 @@ impl PyPalace {
         let dc = palace.storage().drawer_count();
         let wc = palace.storage().wing_count();
         Ok(format!(
-            "Palace(path='{}', name='{}', wings={}, drawers={})",
-            self.path, self.name, wc, dc
+            "Palace(path='{}', name='{}', wings={}, drawers={}, auto_save={})",
+            self.path, self.name, wc, dc, self.auto_save
         ))
     }
 }

--- a/rust/gp-storage/src/memory.rs
+++ b/rust/gp-storage/src/memory.rs
@@ -29,6 +29,13 @@ pub struct Relationship {
     pub valid_from: Option<String>,
     pub valid_to: Option<String>,
     pub observed_at: String,
+    /// Timestamp when this triple was retracted/invalidated in the system.
+    /// Distinct from `valid_to` (which marks the assertion validity window).
+    #[serde(default)]
+    pub invalidated_at: Option<String>,
+    /// Classification: fact, observation, inference, hypothesis.
+    #[serde(default)]
+    pub statement_type: gp_core::types::StatementType,
 }
 
 /// Internal data store shared across threads.
@@ -479,6 +486,28 @@ impl InMemoryBackend {
         object: &str,
         confidence: f64,
     ) -> Result<String> {
+        self.add_relationship_temporal(
+            subject,
+            predicate,
+            object,
+            confidence,
+            None,
+            None,
+            gp_core::types::StatementType::default(),
+        )
+    }
+
+    /// Add a relationship with full bi-temporal and statement-type metadata.
+    pub fn add_relationship_temporal(
+        &self,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+        confidence: f64,
+        valid_from: Option<String>,
+        valid_to: Option<String>,
+        statement_type: gp_core::types::StatementType,
+    ) -> Result<String> {
         let mut d = self.write_data();
         let id = d.gen_id("rel");
         let rel = Relationship {
@@ -487,9 +516,11 @@ impl InMemoryBackend {
             predicate: predicate.to_string(),
             object: object.to_string(),
             confidence,
-            valid_from: None,
-            valid_to: None,
+            valid_from,
+            valid_to,
             observed_at: Utc::now().to_rfc3339(),
+            invalidated_at: None,
+            statement_type,
         };
         d.relationships.push(rel);
         // Edge pheromones for the relationship
@@ -796,15 +827,20 @@ impl InMemoryBackend {
 
     // -- Relationship invalidation & contradictions ----------------------------
 
-    /// Invalidate a relationship by setting its valid_to timestamp.
+    /// Invalidate a relationship by setting its `invalidated_at` timestamp
+    /// (system time of retraction) and closing `valid_to` if still open.
     /// Marks the relationship as no longer current without deleting it.
     pub fn invalidate_relationship(&self, subject: &str, predicate: &str, object: &str) -> bool {
         let mut d = self.write_data();
         let now = chrono::Utc::now().to_rfc3339();
         let mut found = false;
         for rel in d.relationships.iter_mut() {
-            if rel.subject == subject && rel.predicate == predicate && rel.object == object && rel.valid_to.is_none() {
-                rel.valid_to = Some(now.clone());
+            if rel.subject == subject && rel.predicate == predicate && rel.object == object && rel.invalidated_at.is_none() {
+                rel.invalidated_at = Some(now.clone());
+                // Also close the validity window if still open.
+                if rel.valid_to.is_none() {
+                    rel.valid_to = Some(now.clone());
+                }
                 found = true;
             }
         }
@@ -817,7 +853,7 @@ impl InMemoryBackend {
     pub fn find_contradictions(&self, entity: &str) -> Vec<(Relationship, Relationship)> {
         let d = self.read_data();
         let rels: Vec<&Relationship> = d.relationships.iter()
-            .filter(|r| (r.subject == entity || r.object == entity) && r.valid_to.is_none())
+            .filter(|r| (r.subject == entity || r.object == entity) && r.invalidated_at.is_none())
             .collect();
         let mut contradictions = Vec::new();
         for i in 0..rels.len() {

--- a/skills/graphpalace.md
+++ b/skills/graphpalace.md
@@ -262,7 +262,7 @@ ORDER BY cnt DESC
 | `add_drawer` | `content`, `wing`, `room`, `source?` | New drawer ID (auto-embedded) | Storing a new memory (always `check_duplicate` first!) |
 | `delete_drawer` | `drawer_id` | Confirmation | Removing incorrect or duplicate content |
 | `add_wing` | `name`, `type`, `description` | New wing ID | Creating a new domain/project/person area |
-| `add_room` | `wing_id`, `name`, `hall_type` | New room ID | Adding a subject area within a wing |
+| `add_room` | `wing_id`, `name`, `hall_type`, `description?` | New room ID | Adding a subject area within a wing |
 | `check_duplicate` | `content`, `threshold?` | Similar existing drawers | **Call before `add_drawer`** — prevent duplicates |
 
 ### Knowledge Graph
@@ -384,6 +384,63 @@ ORDER BY cnt DESC
 4. add_room(wing_id=new_wing_id, name="hardware", hall_type="facts")
 5. (Add drawers with content to each room)
 ```
+
+---
+
+## CLI Quick Reference
+
+The `graphpalace` CLI mirrors the MCP tools above. Global flags go **before** the subcommand:
+
+```
+graphpalace -d <palace_dir> [-c config.toml] [-q] <command>
+```
+
+| Flag | Short | Default | Purpose |
+|------|:-----:|---------|---------|
+| `--db` | `-d` | `./palace` | Path to palace database directory |
+| `--config` | `-c` | `graphpalace.toml` | Config file path |
+| `--quiet` | `-q` | off | Suppress informational messages (e.g. tunnel build counts) |
+
+### Common commands
+
+```bash
+# Initialize a new palace
+graphpalace -d .palace init --name "My Palace"
+
+# Wing operations
+graphpalace -d .palace wing list
+graphpalace -d .palace wing add <name> -t domain -d "description"
+#   -t/--wing-type: person | project | domain | topic (default: topic)
+#   -d/--description: optional wing description
+
+# Room operations
+graphpalace -d .palace room list <wing>
+graphpalace -d .palace room add <wing> <name> -t facts -d "description"
+#   -t/--hall-type: facts | events | discoveries | preferences | advice (default: facts)
+#   -d/--description: optional room description
+
+# Add a memory (drawer)
+graphpalace -d .palace add-drawer -c "content" -w wing -r room -s conversation
+#   -s/--source: conversation | file | api | agent
+
+# Semantic search
+graphpalace -d .palace search "query" -k 5
+
+# Knowledge graph
+graphpalace -d .palace kg add "subject" "predicate" "object" --confidence 0.8
+graphpalace -d .palace kg query "entity"
+graphpalace -d .palace kg timeline "entity"
+
+# Navigation & structure
+graphpalace -d .palace navigate <from_id> <to_id>
+graphpalace -d .palace status --verbose
+graphpalace -d .palace export -o backup.json
+
+# Start MCP server (stdin/stdout JSON-RPC)
+graphpalace -d .palace serve
+```
+
+> **Note:** The MCP tools table above documents the **server-side tool interface** (used via `serve`). The CLI subcommands listed here provide equivalent functionality for direct terminal use.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR addresses **all 7 open issues** in a single cohesive changeset.

### Issues Resolved

| Issue | Title | Type |
|-------|-------|------|
| #2 | [PyO3] Expose remaining Rust API methods | enhancement |
| #3 | [PyO3] Add batch mode / deferred save | enhancement |
| #4 | [API] search() always returns error | **bug** |
| #5 | [PyO3] Expose ONNX embedding engine option | enhancement |
| #6 | [KG] Bi-temporal support for knowledge graph | enhancement |
| #7 | [Feature] Duplicate detection via public API + PyO3 | enhancement |
| #8 | CLAUDE.md/skills CLI flag inaccuracies + improvements | bug/docs |

### Changes by Area

#### Core API (`gp-palace`, `gp-core`, `gp-storage`)
- **search() now works** (#4): Wrapped `embeddings` in `RefCell` for interior mutability. `search(&self)` encodes queries directly — no more confusing error stub. `search_mut()` deprecated but kept as alias.
- **Bi-temporal KG** (#6): Added `StatementType` enum (Fact/Observation/Inference/Hypothesis), `invalidated_at` timestamp, and `kg_add_temporal()` method. `kg_invalidate()` now sets `invalidated_at` + closes `valid_to`. All fields use `#[serde(default)]` for backward compat.
- **Duplicate detection** (#7): Added `DuplicateMatch` struct, `check_duplicate()`, and `add_drawer_if_unique()` to the public API.
- **Room descriptions** (#8): Added `add_room_with_description()` with backward-compatible `add_room()` delegation.

#### Python Bindings (`gp-python`)
- **13 new methods** (#2): `deposit_pheromones`, `kg_invalidate`, `kg_contradictions`, `kg_add_with_confidence`, `build_tunnels`, `create_agent`, `list_agents`, `diary_write`, `diary_read`, `search_by_embedding`, `similarity_edge_count`, `kg_add_temporal`, `extract_entities`
- **Batch mode** (#3): `auto_save` property (default True). Set to False for bulk operations, call `save()` manually.
- **Duplicate detection** (#7): `check_duplicate()` and `add_drawer_if_unique()` exposed to Python.
- **ONNX option** (#5): `embedding` parameter in constructor (groundwork for feature-gated ONNX).
- Total methods: **21 → 34** (full API coverage).

#### CLI (`gp-cli`)
- **`--quiet/-q`** global flag suppresses tunnel build messages (#8)
- **`--description/-d`** on `room add` (#8)
- Temporal KG params in MCP `kg_add` handler (#6)
- `search_mut` → `search` migration (#4)

#### MCP Tools (`gp-mcp`)
- `add_room`: added optional `description` parameter
- `kg_add`: added optional `valid_from`, `valid_to`, `statement_type` parameters

#### Documentation (`skills/graphpalace.md`)
- Added **CLI Quick Reference** section with correct flag syntax
- Updated MCP tools table with new parameters
- Documented global flags (`-d`, `-c`, `-q`)

### Backward Compatibility
- All new struct fields use `#[serde(default)]` — existing serialized data loads without issues
- `search_mut()` deprecated but still works (delegates to `search()`)
- `add_room()` unchanged (delegates to `add_room_with_description(_, _, _, None)`)
- `kg_add()` unchanged (delegates to `kg_add_with_confidence`)
- Constructor signature unchanged (`Box<dyn EmbeddingEngine>`, RefCell wrapping is internal)

### Files Changed (15)
```
rust/gp-core/src/types.rs           +39   StatementType, RelatesTo fields
rust/gp-storage/src/memory.rs       +48   Relationship fields, temporal methods
rust/gp-palace/src/palace.rs       +177   RefCell, check_duplicate, kg_add_temporal, room desc
rust/gp-palace/src/search.rs        +15   DuplicateMatch struct
rust/gp-palace/src/lifecycle.rs     +54   KgRelationship temporal fields + tests
rust/gp-palace/src/lib.rs            +1   Export DuplicateMatch
rust/gp-python/src/lib.rs          +407   13 methods, batch mode, temporal, dedup
rust/gp-cli/src/main.rs            +106   --quiet, room desc, temporal handlers
rust/gp-mcp/src/tools.rs            +64   Tool schemas + tests
rust/gp-bench/*/                     +6   search migration
rust/gp-palace/tests/                +6   search migration
skills/graphpalace.md               +59   CLI Quick Reference
```

Closes #2, closes #3, closes #4, closes #5, closes #6, closes #7, closes #8